### PR TITLE
adding figma links to the components I have in figma

### DIFF
--- a/borders/design/figma.link
+++ b/borders/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=143%3A22176

--- a/button/design/figma.link
+++ b/button/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=118%3A2454

--- a/checkbox-group/design/figma.link
+++ b/checkbox-group/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=114%3A2195

--- a/collapsible/design/figma.link
+++ b/collapsible/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=114%3A2194

--- a/colors/design/figma.link
+++ b/colors/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=143%3A22174

--- a/dialog/design/figma.link
+++ b/dialog/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=114%3A2219

--- a/icons/design/figma.link
+++ b/icons/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=116%3A1824

--- a/input-datepicker/design/figma.link
+++ b/input-datepicker/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=117%3A1853

--- a/input-range/design/figma.link
+++ b/input-range/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=131%3A42925

--- a/input/design/figma.link
+++ b/input/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=117%3A1838

--- a/introduction/design/figma.link
+++ b/introduction/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=104%3A1447

--- a/radio-group/design/figma.link
+++ b/radio-group/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=114%3A2210

--- a/select/design/figma.link
+++ b/select/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=117%3A1928

--- a/spacing/design/figma.link
+++ b/spacing/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=143%3A22178

--- a/switch/design/figma.link
+++ b/switch/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=117%3A1929

--- a/textarea/design/figma.link
+++ b/textarea/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=117%3A1846

--- a/tooltip/design/figma.link
+++ b/tooltip/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=114%3A1871

--- a/typography/design/figma.link
+++ b/typography/design/figma.link
@@ -1,0 +1,1 @@
+https://www.figma.com/file/nIUq8BrLFDWojnKRYt4qAo/Simba?node-id=143%3A22179


### PR DESCRIPTION
The following pages now have a matching figma reference: colors, borders, typography, spacing.

As well as components available: button, collapsible, checkbox-group, dialog, icons, input, input-datepicker, input-range, radio-group, select, switch, textarea, tooltip.

With this users should be able to have an example of how to start their collaboration with designers in Simba.

Todo: better guidelines on how to use the figma file.